### PR TITLE
Delete existing tags after cloning

### DIFF
--- a/project_setup/scripts/skeleton
+++ b/project_setup/scripts/skeleton
@@ -63,8 +63,7 @@ def clone_repo(parent_repo, new_repo, org, dir=None):
         f"git remote add origin git@github.com:{org}/{new_repo}.git",
         "Add a new remote origin for the this repository.",
     )
-    run(f"git tag -d $(git tag -l)",
-        f"Delete all local git tags from {parent_repo}")
+    run(f"git tag -d $(git tag -l)", f"Delete all local git tags from {parent_repo}")
     run(
         fr"""find . \( ! -regex '.*/\.git/.*' \) -type f -print0 | """
         fr'''xargs -0 sed -i "" "s/{parent_repo}/{new_repo}/g"''',

--- a/project_setup/scripts/skeleton
+++ b/project_setup/scripts/skeleton
@@ -63,6 +63,8 @@ def clone_repo(parent_repo, new_repo, org, dir=None):
         f"git remote add origin git@github.com:{org}/{new_repo}.git",
         "Add a new remote origin for the this repository.",
     )
+    run(f"git tag -d $(git tag -l)",
+        f"Delete all local git tags from {parent_repo}")
     run(
         fr"""find . \( ! -regex '.*/\.git/.*' \) -type f -print0 | """
         fr'''xargs -0 sed -i "" "s/{parent_repo}/{new_repo}/g"''',


### PR DESCRIPTION
If the parent repo has version tags (as [cisagov/skeleton-packer](https://github.com/cisagov/skeleton-packer) does, for example) then those tags will be carried over into the child repo.  We don't want that, and we want our child repo to start with no tags, so let's delete the local tags.