### PR TITLE
Change the sed code to also work on linux

### DIFF
--- a/project_setup/scripts/skeleton
+++ b/project_setup/scripts/skeleton
@@ -64,8 +64,8 @@ def clone_repo(parent_repo, new_repo, org, dir=None):
         "Add a new remote origin for the this repository.",
     )
     run(
-        fr"""find . \( ! -regex '.*/\.git/.*' \) -type f -print0 | """
-        fr'''xargs -0 sed -i "" "s/{parent_repo}/{new_repo}/g"''',
+        f"find . \( ! -regex '.*/\.git/.*' \) -type f -exec "
+        f'perl -pi -e s/{parent_repo}/{new_repo}/g {{}} \;',
         "Search and replace repository name in source files.",
     )
     run("git add --verbose .", "Stage modified files.")

--- a/project_setup/scripts/skeleton
+++ b/project_setup/scripts/skeleton
@@ -64,8 +64,8 @@ def clone_repo(parent_repo, new_repo, org, dir=None):
         "Add a new remote origin for the this repository.",
     )
     run(
-        f"find . \( ! -regex '.*/\.git/.*' \) -type f -exec "
-        f'perl -pi -e s/{parent_repo}/{new_repo}/g {{}} \;',
+        fr"find . \( ! -regex '.*/\.git/.*' \) -type f -exec "
+        fr"perl -pi -e s/{parent_repo}/{new_repo}/g {{}} \;",
         "Search and replace repository name in source files.",
     )
     run("git add --verbose .", "Stage modified files.")


### PR DESCRIPTION
`sed -i` only works on linux, and `sed -i ""` only works on OSX, but both linux and OSX can use `perl` to execute an in-place regex.  (Any port in a storm, I suppose.)

I also simplified the code to use the simpler `find -exec` idiom, instead of the more complicated `find -print0 | xargs` idiom.