### PR TITLE
terraform-to-secrets: Handle case where tags are None

### DIFF
--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -129,9 +129,13 @@ def parse_tagged_resources(
 ) -> Generator[Tuple[str, str], None, None]:
     """Search all resources for tags requesting the creation of a secret."""
     for resource in find_resources(terraform_state, None):
-        tags: Dict[str, str] = resource["values"].get("tags", dict())
-        if tags is None:
+        # Ensure "tags" key exists in resource["values"] and if it does,
+        # make sure its value is not None.  Both of these cases can occur.
+        tags: Dict[str, str]
+        if "tags" not in resource["values"] or resource["values"].get("tags") is None:
             tags = dict()
+        else:
+            tags = resource["values"]["tags"]
         secret_name: Optional[str] = tags.get(GITHUB_SECRET_NAME_TAG)
         lookup_tag: Optional[str] = tags.get(GITHUB_SECRET_TERRAFORM_LOOKUP_TAG)
         secret_value: str

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -130,6 +130,8 @@ def parse_tagged_resources(
     """Search all resources for tags requesting the creation of a secret."""
     for resource in find_resources(terraform_state, None):
         tags: Dict[str, str] = resource["values"].get("tags", dict())
+        if tags is None:
+            tags = dict()
         secret_name: Optional[str] = tags.get(GITHUB_SECRET_NAME_TAG)
         lookup_tag: Optional[str] = tags.get(GITHUB_SECRET_TERRAFORM_LOOKUP_TAG)
         secret_value: str


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds a check in `terraform-to-secrets` to verify that a resource's tags are not equal to `None`.  If the tags are `None`, it's value is changed to an empty dictionary so that the rest of the script runs correctly..

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
I encountered a situation recently where `terraform-to-secrets` was failing:

```
❱ terraform-to-secrets -l debug -d -t <REDACTED>
2020-04-11 09:48:07,985 DEBUG Trying to determine GitHub repository name using git.
2020-04-11 09:48:08,005 INFO Using GitHub repository name: cisagov/nessus-packer
2020-04-11 09:48:08,006 INFO Reading state from Terraform command.
2020-04-11 09:48:10,603 INFO Searching Terraform state for IAM credentials.
2020-04-11 09:48:10,603 INFO Found credentials for user: test-nessus-packer
2020-04-11 09:48:10,603 INFO Searching Terraform state for tagged resources.
2020-04-11 09:48:10,603 DEBUG: resource[address]: aws_iam_policy.s3_read tags: {}
2020-04-11 09:48:10,603 DEBUG: resource[address]: aws_iam_role.s3_read tags: None
Traceback (most recent call last):
  File "development-guide/bin/terraform-to-secrets", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "development-guide/project_setup/scripts/terraform-to-secrets", line 399, in <module>
    sys.exit(main())
  File "development-guide/project_setup/scripts/terraform-to-secrets", line 380, in main
    resource_secrets: Dict[str, str] = get_resource_secrets(terraform_state)
  File "development-guide/project_setup/scripts/terraform-to-secrets", line 246, in get_resource_secrets
    for secret_name, secret_value in parse_tagged_resources(terraform_state):
  File "development-guide/project_setup/scripts/terraform-to-secrets", line 136, in parse_tagged_resources
    secret_name: Optional[str] = tags.get(GITHUB_SECRET_NAME_TAG)
AttributeError: 'NoneType' object has no attribute 'get'
```
The output above shows the two additional lines of debug output that I added to illustrate the problem:
```
2020-04-11 09:48:10,603 DEBUG: resource[address]: aws_iam_policy.s3_read tags: {}
2020-04-11 09:48:10,603 DEBUG: resource[address]: aws_iam_role.s3_read tags: None
```

Note that the `aws_iam_role.s3_read` resource had a `tags` element, but its value was set to `None`, which caused the `AttributeError` seen above. 

I am not sure if something in AWS or Terraform changed recently to cause this behavior or if we have just never created a role without any tags before.

The code in this PR simply does a check for this situation and if it occurs, it replaces `None` with an empty dictionary so that processing can continue.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested the fix locally and verified that the script ran successfully.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
