### PR TITLE
terraform-to-secrets: Search for secrets in resource outputs

### DIFF
--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -98,7 +98,9 @@ def get_terraform_state(filename: str = None) -> Dict:
     return json_state
 
 
-def find_tagged_secret(resource_name: str, resource_data: Dict) -> Tuple[str, str]:
+def find_tagged_secret(
+    resource_name: str, resource_data: Dict
+) -> Generator[Tuple[str, str], None, None]:
     """Extract a tagged secret from a resource."""
     # Ensure "tags" key exists in resource_data and if it does, make sure
     # its value is not None.  Both of these cases can occur.
@@ -126,12 +128,12 @@ def find_tagged_secret(resource_name: str, resource_data: Dict) -> Tuple[str, st
                 logging.warning(f"Could not lookup value with key {lookup_tag}")
             else:
                 logging.debug(f"Looked up value: {secret_value}")
-                return secret_name, secret_value
+                yield secret_name, secret_value
         else:
             logging.warning(
                 f"Missing {GITHUB_SECRET_TERRAFORM_LOOKUP_TAG} on " f"{resource_name}."
             )
-    return "", ""
+    return
 
 
 def find_outputs(terraform_state: Dict) -> Generator[Dict, None, None]:
@@ -147,8 +149,9 @@ def parse_tagged_outputs(
     """Search all outputs for tags requesting the creation of a secret."""
     for outputs in find_outputs(terraform_state):
         for output_name, output_data in outputs.items():
-            secret_name, secret_value = find_tagged_secret(output_name, output_data)
-            if secret_name:
+            for secret_name, secret_value in find_tagged_secret(
+                output_name, output_data
+            ):
                 yield secret_name, secret_value
     return
 
@@ -184,10 +187,9 @@ def parse_tagged_resources(
 ) -> Generator[Tuple[str, str], None, None]:
     """Search all resources for tags requesting the creation of a secret."""
     for resource in find_resources(terraform_state, None):
-        secret_name, secret_value = find_tagged_secret(
+        for secret_name, secret_value in find_tagged_secret(
             resource["address"], resource["values"]
-        )
-        if secret_name:
+        ):
             yield secret_name, secret_value
     return
 

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -134,6 +134,25 @@ def find_tagged_secret(resource_name: str, resource_data: Dict) -> Tuple[str, st
     return "", ""
 
 
+def find_outputs(terraform_state: Dict) -> Generator[Dict, None, None]:
+    """Search for resources with outputs in the Terraform state."""
+    for resource in terraform_state["values"]["root_module"]["resources"]:
+        if resource.get("values", dict()).get("outputs", dict()):
+            yield resource["values"]["outputs"]
+
+
+def parse_tagged_outputs(
+    terraform_state: Dict,
+) -> Generator[Tuple[str, str], None, None]:
+    """Search all outputs for tags requesting the creation of a secret."""
+    for outputs in find_outputs(terraform_state):
+        for output_name, output_data in outputs.items():
+            secret_name, secret_value = find_tagged_secret(output_name, output_data)
+            if secret_name:
+                yield secret_name, secret_value
+    return
+
+
 def find_resources(
     terraform_state: Dict, resource_type: Optional[str]
 ) -> Generator[Dict, None, None]:
@@ -257,6 +276,9 @@ def get_resource_secrets(terraform_state: Dict) -> Dict[str, str]:
     secrets: Dict[str, str] = dict()
     logging.info("Searching Terraform state for tagged resources.")
     for secret_name, secret_value in parse_tagged_resources(terraform_state):
+        logging.info(f"Found secret: {secret_name}")
+        secrets[secret_name] = secret_value
+    for secret_name, secret_value in parse_tagged_outputs(terraform_state):
         logging.info(f"Found secret: {secret_name}")
         secrets[secret_name] = secret_value
     return secrets

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -98,6 +98,42 @@ def get_terraform_state(filename: str = None) -> Dict:
     return json_state
 
 
+def find_tagged_secret(resource_name: str, resource_data: Dict) -> Tuple[str, str]:
+    """Extract a tagged secret from a resource."""
+    # Ensure "tags" key exists in resource_data and if it does, make sure
+    # its value is not None.  Both of these cases can occur.
+    tags: Dict[str, str]
+    if "tags" not in resource_data or resource_data.get("tags") is None:
+        tags = dict()
+    else:
+        tags = resource_data["tags"]
+
+    secret_name: Optional[str] = tags.get(GITHUB_SECRET_NAME_TAG)
+    lookup_tag: Optional[str] = tags.get(GITHUB_SECRET_TERRAFORM_LOOKUP_TAG)
+    secret_value: Optional[str]
+    if secret_name:
+        logging.debug(
+            f"Found {GITHUB_SECRET_NAME_TAG} on {resource_name} "
+            f"with value {secret_name}"
+        )
+        if lookup_tag:
+            logging.debug(
+                f"Found {GITHUB_SECRET_TERRAFORM_LOOKUP_TAG} on "
+                f"{resource_name} with value {lookup_tag}"
+            )
+            secret_value = resource_data.get(lookup_tag)
+            if secret_value is None:
+                logging.warning(f"Could not lookup value with key {lookup_tag}")
+            else:
+                logging.debug(f"Looked up value: {secret_value}")
+                return secret_name, secret_value
+        else:
+            logging.warning(
+                f"Missing {GITHUB_SECRET_TERRAFORM_LOOKUP_TAG} on " f"{resource_name}."
+            )
+    return "", ""
+
+
 def find_resources(
     terraform_state: Dict, resource_type: Optional[str]
 ) -> Generator[Dict, None, None]:

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -165,37 +165,11 @@ def parse_tagged_resources(
 ) -> Generator[Tuple[str, str], None, None]:
     """Search all resources for tags requesting the creation of a secret."""
     for resource in find_resources(terraform_state, None):
-        # Ensure "tags" key exists in resource["values"] and if it does,
-        # make sure its value is not None.  Both of these cases can occur.
-        tags: Dict[str, str]
-        if "tags" not in resource["values"] or resource["values"].get("tags") is None:
-            tags = dict()
-        else:
-            tags = resource["values"]["tags"]
-        secret_name: Optional[str] = tags.get(GITHUB_SECRET_NAME_TAG)
-        lookup_tag: Optional[str] = tags.get(GITHUB_SECRET_TERRAFORM_LOOKUP_TAG)
-        secret_value: str
+        secret_name, secret_value = find_tagged_secret(
+            resource["address"], resource["values"]
+        )
         if secret_name:
-            logging.debug(
-                f"Found {GITHUB_SECRET_NAME_TAG} on {resource['address']} "
-                f"with value {secret_name}"
-            )
-            if lookup_tag:
-                logging.debug(
-                    f"Found {GITHUB_SECRET_TERRAFORM_LOOKUP_TAG} on "
-                    f"{resource['address']} with value {lookup_tag}"
-                )
-                secret_value = resource["values"].get(lookup_tag)
-                if secret_value is None:
-                    logging.warning(f"Could not lookup value with key {lookup_tag}")
-                else:
-                    logging.debug(f"Looked up value: {secret_value}")
-                    yield secret_name, secret_value
-            else:
-                logging.warning(
-                    f"Missing {GITHUB_SECRET_TERRAFORM_LOOKUP_TAG} on "
-                    f"{resource['address']}."
-                )
+            yield secret_name, secret_value
     return
 
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates `terraform-to-secrets` so that it also searches for tagged secrets in resource outputs, such as with Terraform remote states.
 
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
In some cases, a secret is needed that was not created by the local Terraform code.  An example of this is the [Terraform test user in `nessus-packer`](https://github.com/cisagov/nessus-packer/terraform-test-user), which requires the `id` of the ["third-party" bucket created in `cool-accounts/images`](https://github.com/cisagov/cool-accounts/blob/develop/images/third_party_bucket.tf).  If we tag the bucket appropriately (in [`cool-accounts/images`](https://github.com/cisagov/cool-accounts/blob/develop/images/third_party_bucket.tf), then the code in this PR allows that secret to be discovered.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
To test this, I tagged the "third-party" bucket in Staging like so:
```
  tags = merge(var.tags,
    {
      "GitHub_Secret_Name"             = "THIRD_PARTY_BUCKET_${upper(local.this_account_type)}",
      "GitHub_Secret_Terraform_Lookup" = "id"
    }
  )
```
Then, I applied that change in Staging and verified that `terraform-to-secrets` was able to successfully detect the bucket name (`id`) as a secret.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
