### PR TITLE
[terraform-to-secrets] Include root module in search for resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -163,6 +163,10 @@ def find_resources(
 
     resource_type None yields all resources.
     """
+    for resource in terraform_state["values"]["root_module"]["resources"]:
+        if resource_type is None or resource["type"] == resource_type:
+            yield resource
+
     for child_module in terraform_state["values"]["root_module"]["child_modules"]:
         for resource in child_module["resources"]:
             if resource_type is None or resource["type"] == resource_type:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the terraform root module into scope when searching for resources such as user credentials or resources tagged as secrets.

I also took this opportunity to add @hillaryj to the list of CODEOWNERS.
 
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
I am working on updating the Terraform that creates the test user for ([`ansible-role-nessus`](https://github.com/cisagov/ansible-role-nessus)) and in that project, the user credentials (AWS access key and secret) will reside in the root module of the Terraform state.  This PR will allow `terraform-to-secrets` to find those credentials and upload them as GitHub Secrets.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested this code change in several Terraform directories and it worked as expected in every case.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
