### PR TITLE
[terraform-to-secrets] Properly detect resources child modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # these owners will be requested for review when someone
 # opens a pull request.
-*       @dav3r @felddy @hillaryj @jsf9k @mcdonnnj @cisagov/team-ois
+*       @dav3r @felddy

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -156,6 +156,26 @@ def parse_tagged_outputs(
     return
 
 
+def find_resources_in_child_modules(
+    child_modules: list, resource_type: Optional[str]
+) -> Generator[Dict, None, None]:
+    """
+    Search for resources of a certain type in a Terraform child_modules list.
+
+    resource_type None yields all resources.
+    """
+    for child_module in child_modules:
+        for resource in child_module["resources"]:
+            if resource_type is None or resource["type"] == resource_type:
+                yield resource
+
+        if "child_modules" in child_module:
+            for resource in find_resources_in_child_modules(
+                child_module["child_modules"], resource_type
+            ):
+                yield resource
+
+
 def find_resources(
     terraform_state: Dict, resource_type: Optional[str]
 ) -> Generator[Dict, None, None]:
@@ -167,10 +187,11 @@ def find_resources(
         if resource_type is None or resource["type"] == resource_type:
             yield resource
 
-    for child_module in terraform_state["values"]["root_module"]["child_modules"]:
-        for resource in child_module["resources"]:
-            if resource_type is None or resource["type"] == resource_type:
-                yield resource
+    if "child_modules" in terraform_state["values"]["root_module"]:
+        for resource in find_resources_in_child_modules(
+            terraform_state["values"]["root_module"]["child_modules"], resource_type
+        ):
+            yield resource
 
 
 def parse_creds(terraform_state: Dict) -> Generator[Tuple[str, str, str], None, None]:

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -138,7 +138,7 @@ def find_tagged_secret(
 
 def find_outputs(terraform_state: Dict) -> Generator[Dict, None, None]:
     """Search for resources with outputs in the Terraform state."""
-    for resource in terraform_state["values"]["root_module"]["resources"]:
+    for resource in terraform_state["values"]["root_module"].get("resources", []):
         if resource.get("values", dict()).get("outputs", dict()):
             yield resource["values"]["outputs"]
 
@@ -165,7 +165,7 @@ def find_resources_in_child_modules(
     resource_type None yields all resources.
     """
     for child_module in child_modules:
-        for resource in child_module["resources"]:
+        for resource in child_module.get("resources", []):
             if resource_type is None or resource["type"] == resource_type:
                 yield resource
 
@@ -183,7 +183,7 @@ def find_resources(
 
     resource_type None yields all resources.
     """
-    for resource in terraform_state["values"]["root_module"]["resources"]:
+    for resource in terraform_state["values"]["root_module"].get("resources", []):
         if resource_type is None or resource["type"] == resource_type:
             yield resource
 


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates `terraform-to-secrets` so that it properly detects resources in Terraform states with nested child modules or no child modules at all.

Resolves #18.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We need to make sure that our homegrown tools function properly now that we are using Terraform modules more and more.  See #18 for an example of what is being fixed here.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I verified that the correct resources were being detected in [`ansible-role-kali`](https://github.com/cisagov/ansible-role-kali/),  [`nessus-packer`](https://github.com/cisagov/nessus-packer), and [`pca-gophish-composition-packer`](https://github.com/cisagov/pca-gophish-composition-packer).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
