### PR TITLE
Add "Require conversation resolution before merging" to branch protection documentation

### DIFF
--- a/project_setup/README.md
+++ b/project_setup/README.md
@@ -23,6 +23,7 @@ branch protection - [see our branch protection guide for details](branch-protect
   - [Selecting a skeleton](#selecting-a-skeleton)
   - [Cloning a selected skeleton](#cloning-a-selected-skeleton)
 - [Create and publish the GitHub repository](#create-and-publish-the-github-repository)
+- [Disabling squash merging](#disabling-squash-merging)
 - [Set up your environment and pre-commit](#set-up-your-environment-and-pre-commit)
 - [Create an initial pull request](#create-an-initial-pull-request)
 - [Setting up branch protection](#setting-up-branch-protection)
@@ -160,6 +161,12 @@ Next, publish your new repository to GitHub:
 ```bash
 git push --set-upstream origin develop
 ```
+
+## Disabling squash merging ##
+
+Click on the settings tab for your new repository and, in the
+"Options" section, make sure that "Allow squash merging" is
+_unchecked_.
 
 ## Set up your environment and pre-commit ##
 

--- a/project_setup/branch-protection.md
+++ b/project_setup/branch-protection.md
@@ -34,7 +34,7 @@ In `Settings`, go to the `Branches` entry and create a rule with the following:
   - [X] Include administrators
   - [X] Restrict who can push to matching branches
     - Note: this allows by default "People, teams or apps with push access", so
-you likely don't have to make any changes under this entry
+you likely don't have to make any changes _under_ this entry
 
 - Rules applied to everyone including administrators
   - [ ] Allow force pushes

--- a/project_setup/branch-protection.md
+++ b/project_setup/branch-protection.md
@@ -22,12 +22,13 @@ In `Settings`, go to the `Branches` entry and create a rule with the following:
     - [X] Require review from Code Owners
     - [X] Restrict who can dismiss pull request reviews
   - [X] Require status checks to pass before merging
-  - [X] Require branches to be up to date before merging
-    - There may be a list of status checks under this option. We require
-    passing status checks to merge, so all status checks should generally be
-    checked as required.
-    - Please note that the list of status checks will not fully populate in a
-    new repository until the first pull request (PR) has been created.
+    - [X] Require branches to be up to date before merging
+      - There may be a list of status checks under this option. We require
+      passing status checks to merge, so all status checks should generally be
+      checked as required.
+      - Please note that the list of status checks will not fully populate in a
+      new repository until the first pull request (PR) has been created.
+  - [X] Require conversation resolution before merging
   - [ ] Require signed commits
   - [ ] Require linear history
   - [X] Include administrators


### PR DESCRIPTION
## 🗣 Description ##
This PR adds the "Require conversation resolution before merging" checkbox to our standard branch protection setup.  It also adds a blurb about disabling squash merges.  While I was here, I also cleaned up some indentation to match the indentation displayed on the branch protection page in the GitHub web GUI.

## 💭 Motivation and context ##

We want to ensure that our PRs are not merged before all conversations have been properly resolved.

## 🧪 Testing ##

Visual verification of Markdown changes.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
