### PR TITLE
Fix broken Python packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     python_requires=">=3.6",
     # What does your project relate to?
     keywords="documentation",
+    package_dir={"": "project_setup/scripts"},
     install_requires=[
         "boto3",
         "docopt",


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `package_dir` attribute to `setup.py` in order to address broken Python packaging.

Note that this pull request cannot be merged until after #70 is approved and merged.

## 💭 Motivation and context ##

Since this Python module doesn't use a standard src-layout, `setuptools` gets confused and is unable to locate the packages to be included in the module.  Since this "Python module" is really just a collection of scripts located in the `project_setup/scripts` directory, we can tell `setuptools` to restrict itself to that directory.

This is yet another reason why #33 is a good idea.

## 🧪 Testing ##

All automated tests pass.  I have used these changes to successfully create a Python virtual environment in which this module is installed.  This was not possible before these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.