### PR TITLE
Add a link about reviewing code effectively, remove Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Heavily "inspired" by the
 
 - [FISMA-Ready GitHub account setup](https://github.com/fisma-ready/github)
 - [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/#seven-rules)
+- [How to Review Code Effectively](https://github.blog/developer-skills/github/how-to-review-code-effectively-a-github-staff-engineers-philosophy/)
 
 ## Tools and services we use ##
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Heavily "inspired" by the
 - [GitHub Actions](https://github.com/features/actions) -
   Continuous integration and delivery
 - [PyPi](https://pypi.org/search/?q=cisagov) - Python package publication
-- [Snyk](https://app.snyk.io/org/cisagov) - Dependency vulnerability management
-  and remediation
 
 ## Installation ##
 

--- a/languages/python/README.md
+++ b/languages/python/README.md
@@ -33,10 +33,10 @@ file of this project for the most up-to-date information.
 ## Correctness and security ##
 
 Our **standard** code vulnerability scanners in cisagov are
-[CodeQL](https://codeql.github.com/),
-[Dependabot](https://docs.github.com/en/code-security/dependabot), and
-[Snyk](https://snyk.io).  By **default** all repositories in the
-organization are scanned by these tools.
+[CodeQL](https://codeql.github.com/) and
+[Dependabot](https://docs.github.com/en/code-security/dependabot).  By
+**default** all repositories in the organization are scanned by these
+tools.
 
 ## Libraries ##
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a link about reviewing code effectively and also removes all mention of Snyk as a tool that we use.

## 💭 Motivation and context ##

- The link about reviewing code effectively encapsulates our recommendations.
- We no longer use Snyk.

## 🧪 Testing ##

I used my eyeballs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.