### PR TITLE
Support GitHub environment secrets in `terraform-to-secrets`

### DIFF
--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -d --dry-run           Don't create secrets.  Just log what would be created.
+  -e --env=ENVNAME       Create secrets in the specified GitHub environment.
   -h --help              Show this message.
   -l --log-level=LEVEL   If specified, then the log level will be set to
                          the specified value.  Valid values are "debug", "info",
@@ -221,12 +222,20 @@ def encrypt(public_key: str, secret_value: str) -> str:
     return b64encode(encrypted).decode("utf-8")
 
 
-def get_public_key(session: requests.Session, repo_name) -> Dict[str, str]:
-    """Fetch the public key for a repository."""
-    logging.info(f"Requesting public key for repository {repo_name}")
-    response = session.get(
-        f"https://api.github.com/repos/{repo_name}/actions/secrets/public-key"
-    )
+def get_public_key(session: requests.Session, repo_name, github_env) -> Dict[str, str]:
+    """Fetch the public key for a repository or environment."""
+    if github_env:
+        logging.info(
+            f"Requesting public key for environment {github_env} in {repo_name}"
+        )
+        response = session.get(
+            f"https://api.github.com/repos/{repo_name}/environments/{github_env}/secrets/public-key"
+        )
+    else:
+        logging.info(f"Requesting public key for repository {repo_name}")
+        response = session.get(
+            f"https://api.github.com/repos/{repo_name}/actions/secrets/public-key"
+        )
     response.raise_for_status()
     return response.json()
 
@@ -234,15 +243,23 @@ def get_public_key(session: requests.Session, repo_name) -> Dict[str, str]:
 def set_secret(
     session: requests.Session,
     repo_name: str,
+    github_env: str,
     secret_name: str,
     secret_value: str,
     public_key: Dict[str, str],
 ) -> None:
     """Create a secret in a repository."""
-    logging.info(f"Creating secret {secret_name}")
+    if github_env:
+        logging.info(f"Creating secret {secret_name} in environment {github_env}")
+        api_url = f"https://api.github.com/repos/{repo_name}/environments/{github_env}/secrets/{secret_name}"
+    else:
+        logging.info(f"Creating repository secret {secret_name}")
+        api_url = (
+            f"https://api.github.com/repos/{repo_name}/actions/secrets/{secret_name}"
+        )
     encrypted_secret_value = encrypt(public_key["key"], secret_value)
     response = session.put(
-        f"https://api.github.com/repos/{repo_name}/actions/secrets/{secret_name}",
+        api_url,
         json={
             "encrypted_value": encrypted_secret_value,
             "key_id": public_key["key_id"],
@@ -321,21 +338,37 @@ def create_user_secrets(user_creds: Dict[str, Tuple[str, str]]) -> Dict[str, str
 
 
 def create_all_secrets(
-    secrets: Dict[str, str], github_token: str, repo_name: str, dry_run: bool = False
+    secrets: Dict[str, str],
+    github_env: str,
+    github_token: str,
+    repo_name: str,
+    dry_run: bool = False,
 ) -> None:
     """Log into GitHub and create all encrypted secrets."""
     logging.info("Creating GitHub API session using personal access token.")
     session: requests.Session = requests.Session()
     session.auth = ("", github_token)
 
-    # Get the repo's public key to be used to encrypt secrets
-    public_key: Dict[str, str] = get_public_key(session, repo_name)
+    # If an environment is specified, verify that it exists
+    if github_env:
+        logging.info(f"Checking if environment {github_env} exists")
+        response = session.get(
+            f"https://api.github.com/repos/{repo_name}/environments/{github_env}"
+        )
+        if response.status_code != 200:
+            logging.critical(f"Environment {github_env} not found in {repo_name}.")
+            raise Exception(f"Environment {github_env} not found in {repo_name}.")
+
+    # Get the repo or environment public key to be used to encrypt secrets
+    public_key: Dict[str, str] = get_public_key(session, repo_name, github_env)
 
     for secret_name, secret_value in secrets.items():
         if dry_run:
             logging.info(f"Would create secret {secret_name}")
         else:
-            set_secret(session, repo_name, secret_name, secret_value, public_key)
+            set_secret(
+                session, repo_name, github_env, secret_name, secret_value, public_key
+            )
 
 
 def main() -> int:
@@ -389,6 +422,7 @@ def main() -> int:
 
     # Assign validated arguments to variables
     dry_run: bool = validated_args["--dry-run"]
+    github_env: str = validated_args["--env"]
     github_token_to_save: str = validated_args["<github-personal-access-token>"]
     log_level: str = validated_args["--log-level"]
     repo_name: str = validated_args["--repo"]
@@ -444,7 +478,7 @@ def main() -> int:
     all_secrets.update(user_secrets)
 
     # All the ducks are in a row, let's do this thang!
-    create_all_secrets(all_secrets, github_token, repo_name, dry_run)
+    create_all_secrets(all_secrets, github_env, github_token, repo_name, dry_run)
 
     logging.info("Success!")
 

--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -248,7 +248,7 @@ def set_secret(
     secret_value: str,
     public_key: Dict[str, str],
 ) -> None:
-    """Create a secret in a repository."""
+    """Create a secret in a repository or environment."""
     if github_env:
         logging.info(f"Creating secret {secret_name} in environment {github_env}")
         api_url = f"https://api.github.com/repos/{repo_name}/environments/{github_env}/secrets/{secret_name}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the `terraform-to-secrets` script to include a new option for specifying the [GitHub environment](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-environment) to store the secret(s) in.  Previously, this script only was able to upload [repository secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As part of our work to properly segment COOL IAM user accounts into their own environments (e.g. Production, Staging, etc.) we plan to take advantage of GitHub Environments to store environment-specific details such as build user roles and third-party bucket names.  In order to do this, it will be extremely useful for `terraform-to-secrets` to be able to store GitHub environment secrets.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by running the modified version of the script in a repo where I created a `staging-a` environment (see [here](https://github.com/cisagov/skeleton-packer/settings/secrets/actions) if you have access).  The script was able to successfully store secrets in that `staging-a` environment.

For regression testing, I confirmed that running the updated script without providing a GitHub environment name worked the same way that it has worked in the past - repository secrets were created, not environment secrets.

I also tested to ensure that error handling works if a non-existent environment name is provided to the script:

```console
❱ terraform-to-secrets --env foobar
2025-01-13 14:50:37,147 INFO Using GitHub repository name: cisagov/skeleton-packer
2025-01-13 14:50:42,911 INFO GitHub token retrieved from keyring.
2025-01-13 14:50:42,911 INFO Reading state from Terraform command.
2025-01-13 14:50:44,188 INFO Searching Terraform state for IAM credentials.
2025-01-13 14:50:44,188 INFO Found credentials for user: build-skeleton-packer
2025-01-13 14:50:44,188 INFO Searching Terraform state for tagged resources.
2025-01-13 14:50:44,188 INFO Found secret: BUILD_ROLE_TO_ASSUME
2025-01-13 14:50:44,188 INFO Found secret: THIRD_PARTY_BUCKET
2025-01-13 14:50:44,188 INFO Creating GitHub API session using personal access token.
2025-01-13 14:50:44,189 INFO Checking if environment foobar exists
2025-01-13 14:50:44,294 CRITICAL Environment foobar not found in cisagov/skeleton-packer.
Traceback (most recent call last):
  File "/Users/dav3r/.pyenv/versions/development-guide/bin/terraform-to-secrets", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/dav3r/code/cisagov/development-guide/project_setup/scripts/terraform-to-secrets", line 489, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/dav3r/code/cisagov/development-guide/project_setup/scripts/terraform-to-secrets", line 481, in main
    create_all_secrets(all_secrets, github_env, github_token, repo_name, dry_run)
  File "/Users/dav3r/code/cisagov/development-guide/project_setup/scripts/terraform-to-secrets", line 360, in create_all_secrets
    raise Exception(f"Environment {github_env} not found in {repo_name}.")
Exception: Environment foobar not found in cisagov/skeleton-packer.
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
