### PR TITLE
Add option to `terraform-to-secrets` to search for secrets in remote state resources

### DIFF
--- a/project_setup/scripts/terraform-to-secrets
+++ b/project_setup/scripts/terraform-to-secrets
@@ -44,6 +44,7 @@ Options:
   -l --log-level=LEVEL   If specified, then the log level will be set to
                          the specified value.  Valid values are "debug", "info",
                          "warning", "error", and "critical". [default: info]
+  -m --remote-state      Look for secrets in remote state resources also.
   -r --repo=REPONAME     Use provided repository name instead of detecting it.
   -s --state=JSONFILE    Read state from a file instead of asking Terraform.
   -t --token=PAT         Specify a GitHub personal access token (PAT).
@@ -137,18 +138,27 @@ def find_tagged_secret(
     return
 
 
-def find_outputs(terraform_state: Dict) -> Generator[Dict, None, None]:
+def find_outputs(
+    terraform_state: Dict, include_remote_state: bool
+) -> Generator[Dict, None, None]:
     """Search for resources with outputs in the Terraform state."""
     for resource in terraform_state["values"]["root_module"].get("resources", []):
+        # Exclude remote state resources unless requested
+        if (
+            not include_remote_state
+            and resource.get("type") == "terraform_remote_state"
+        ):
+            continue
         if resource.get("values", dict()).get("outputs", dict()):
             yield resource["values"]["outputs"]
 
 
 def parse_tagged_outputs(
     terraform_state: Dict,
+    include_remote_state: bool,
 ) -> Generator[Tuple[str, str], None, None]:
     """Search all outputs for tags requesting the creation of a secret."""
-    for outputs in find_outputs(terraform_state):
+    for outputs in find_outputs(terraform_state, include_remote_state):
         for output_name, output_data in outputs.items():
             yield from find_tagged_secret(output_name, output_data)
     return
@@ -207,9 +217,16 @@ def parse_creds(terraform_state: Dict) -> Generator[Tuple[str, str, str], None, 
 
 def parse_tagged_resources(
     terraform_state: Dict,
+    include_remote_state: bool,
 ) -> Generator[Tuple[str, str], None, None]:
     """Search all resources for tags requesting the creation of a secret."""
     for resource in find_resources(terraform_state, None):
+        # Exclude remote state resources unless requested
+        if (
+            not include_remote_state
+            and resource.get("type") == "terraform_remote_state"
+        ):
+            continue
         yield from find_tagged_secret(resource["address"], resource["values"])
     return
 
@@ -309,14 +326,20 @@ def get_users(terraform_state: Dict) -> Dict[str, Tuple[str, str]]:
     return user_creds
 
 
-def get_resource_secrets(terraform_state: Dict) -> Dict[str, str]:
+def get_resource_secrets(
+    terraform_state: Dict, include_remote_state: bool
+) -> Dict[str, str]:
     """Collect secrets from tagged Terraform resources."""
     secrets: Dict[str, str] = dict()
     logging.info("Searching Terraform state for tagged resources.")
-    for secret_name, secret_value in parse_tagged_resources(terraform_state):
+    for secret_name, secret_value in parse_tagged_resources(
+        terraform_state, include_remote_state
+    ):
         logging.info(f"Found secret: {secret_name}")
         secrets[secret_name] = secret_value
-    for secret_name, secret_value in parse_tagged_outputs(terraform_state):
+    for secret_name, secret_value in parse_tagged_outputs(
+        terraform_state, include_remote_state
+    ):
         logging.info(f"Found secret: {secret_name}")
         secrets[secret_name] = secret_value
     return secrets
@@ -425,6 +448,7 @@ def main() -> int:
     github_env: str = validated_args["--env"]
     github_token_to_save: str = validated_args["<github-personal-access-token>"]
     log_level: str = validated_args["--log-level"]
+    include_remote_state: bool = validated_args["--remote-state"]
     repo_name: str = validated_args["--repo"]
     state_filename: str = validated_args["--state"]
     github_token: str = validated_args["--token"]
@@ -467,7 +491,9 @@ def main() -> int:
     user_secrets: Dict[str, str] = create_user_secrets(user_creds)
 
     # Secrets created from tagged resources. Names mapped to value.
-    resource_secrets: Dict[str, str] = get_resource_secrets(terraform_state)
+    resource_secrets: Dict[str, str] = get_resource_secrets(
+        terraform_state, include_remote_state
+    )
 
     # Check if there are overlaps in the keys.
     if not user_secrets.keys().isdisjoint(resource_secrets.keys()):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a new `--remote-state` option to the `terraform-to-secrets` script.  When the option is included, the script will search for secrets in Terraform remote state resources.  When the option is excluded, it will only search for secrets in the local state resources.  This changes the behavior of `terraform-to-secrets` because it would previously search in the remote state by default.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There are some cases when it may be desirable to search for secrets in remote state resources, but generally, we will only want to search the local state.

This change was prompted by a situation (in https://github.com/cisagov/ansible-role-cdm-nessus-agent/pull/62) where the intended `TEST_ROLE_TO_ASSUME` for the `ansible-role-cdm-nessus-agent` was being overwritten by an additional `TEST_ROLE_TO_ASSUME` that was included in the remote state for `ansible-role-cdm-certificates`.  Adding this new option will allow us to avoid situations like this in the future.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested these changes by running the script in a repository that had secrets in both the local state and remote state.  I confirmed that the changes worked as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
